### PR TITLE
feat(dsp): add WOLA framing, constants, and 48 kHz ↔ 16 kHz resamplers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,64 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rfwhisper"
+version = "0.1.0"
+description = "Real-time ML noise reduction for amateur radio"
+readme = "README.md"
+license = { text = "GPL-3.0-or-later" }
+requires-python = ">=3.10"
+dependencies = [
+  "numpy>=1.24",
+  "scipy>=1.10",
+]
+
+[project.optional-dependencies]
+dev = [
+  "mypy>=1.10",
+  "pre-commit",
+  "pytest>=8",
+  "pytest-xdist",
+  "ruff>=0.5",
+]
+audio = [
+  "onnxruntime>=1.15",
+  "scipy>=1.10",
+  "sounddevice>=0.4",
+  "soundfile>=0.12",
+]
+eval = [
+  "pesq",
+  "pystoi",
+  "scipy>=1.10",
+]
+
+[project.scripts]
+rfwhisper = "rfwhisper.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["rfwhisper*"]
+
+[tool.setuptools.package-data]
+rfwhisper = ["py.typed"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "W"]
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = ["pesq", "pystoi", "pesq.pesq"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["scipy.signal"]
+ignore_missing_imports = true

--- a/rfwhisper/__init__.py
+++ b/rfwhisper/__init__.py
@@ -1,0 +1,3 @@
+"""RFWhisper — real-time ML noise reduction for amateur radio."""
+
+__version__ = "0.1.0"

--- a/rfwhisper/cli.py
+++ b/rfwhisper/cli.py
@@ -1,0 +1,12 @@
+"""CLI entrypoint (expanded in later milestones)."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="rfwhisper", description="RFWhisper denoiser CLI")
+    parser.add_argument("--version", action="version", version="rfwhisper 0.1.0")
+    parser.parse_args()
+    parser.print_help()

--- a/rfwhisper/cli.py
+++ b/rfwhisper/cli.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import argparse
 
+from rfwhisper import __version__
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(prog="rfwhisper", description="RFWhisper denoiser CLI")
-    parser.add_argument("--version", action="version", version="rfwhisper 0.1.0")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     parser.parse_args()
     parser.print_help()

--- a/rfwhisper/dsp/__init__.py
+++ b/rfwhisper/dsp/__init__.py
@@ -1,0 +1,26 @@
+"""DSP primitives: framing, windows, overlap-add, resampling."""
+
+from __future__ import annotations
+
+from rfwhisper.dsp.features import (
+    HOP_16K,
+    HOP_48K,
+    WIN_16K,
+    WIN_48K,
+    FrameBuffer,
+    hann_window,
+    stft_frames,
+)
+from rfwhisper.dsp.resample import resample_16k_to_48k, resample_48k_to_16k
+
+__all__ = [
+    "HOP_16K",
+    "HOP_48K",
+    "WIN_16K",
+    "WIN_48K",
+    "FrameBuffer",
+    "hann_window",
+    "resample_16k_to_48k",
+    "resample_48k_to_16k",
+    "stft_frames",
+]

--- a/rfwhisper/dsp/features.py
+++ b/rfwhisper/dsp/features.py
@@ -17,10 +17,12 @@ def hann_window(n: int) -> NDArray[np.float64]:
     """Periodic Hann of length ``n`` (``fftbins=True`` / DFN3 reference convention).
 
     Matches ``scipy.signal.get_window("hann", n, fftbins=True)`` (``sym=False``) within
-    floating error.
+    floating error, including SciPy's length-1 special case (all-ones window).
     """
     if n <= 0:
         raise ValueError("n must be positive")
+    if n == 1:
+        return np.ones(1, dtype=np.float64)
     idx = np.arange(n, dtype=np.float64)
     return 0.5 * (1.0 - np.cos(2.0 * np.pi * idx / float(n)))
 

--- a/rfwhisper/dsp/features.py
+++ b/rfwhisper/dsp/features.py
@@ -1,0 +1,109 @@
+"""Framing, periodic Hann windows, overlap-add, and offline STFT-frame helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.lib.stride_tricks import sliding_window_view
+from numpy.typing import NDArray
+
+# DeepFilterNet3-style framing: 10 ms hop at native rates (ROADMAP / A4).
+HOP_48K: int = 480
+WIN_48K: int = 960
+HOP_16K: int = 160
+WIN_16K: int = 320
+
+
+def hann_window(n: int) -> NDArray[np.float64]:
+    """Periodic Hann of length ``n`` (``fftbins=True`` / DFN3 reference convention).
+
+    Matches ``scipy.signal.get_window("hann", n, fftbins=True)`` (``sym=False``) within
+    floating error.
+    """
+    if n <= 0:
+        raise ValueError("n must be positive")
+    idx = np.arange(n, dtype=np.float64)
+    return 0.5 * (1.0 - np.cos(2.0 * np.pi * idx / float(n)))
+
+
+class FrameBuffer:
+    """Streaming sqrt-Hann analysis + COLA synthesis (WOLA) for one channel.
+
+    * ``push`` ingests ``hop`` new samples.
+    * When ``ready()``, ``next_frame`` returns ``x * sqrt(w)`` where ``w`` is the
+      periodic Hann (``fftbins=True``); advancing the FIFO by ``hop``.
+    * ``overlap_add`` does ``ola += processed * sqrt(w)`` and returns the next ``hop``
+      samples from the accumulator (50 % overlap ⇒ overlapping Hann weights sum to 1).
+    """
+
+    __slots__ = ("_hop", "_in_buf", "_ola", "_win_sqrt", "_win_size")
+
+    def __init__(self, win_size: int, hop: int) -> None:
+        if win_size <= 0 or hop <= 0:
+            raise ValueError("win_size and hop must be positive")
+        if hop > win_size:
+            raise ValueError("hop must not exceed win_size")
+        self._win_size = win_size
+        self._hop = hop
+        w = hann_window(win_size)
+        self._win_sqrt = np.sqrt(w)
+        self._in_buf = np.zeros(0, dtype=np.float64)
+        self._ola = np.zeros(win_size, dtype=np.float64)
+
+    @property
+    def win_size(self) -> int:
+        return self._win_size
+
+    @property
+    def hop(self) -> int:
+        return self._hop
+
+    def push(self, hop_samples: NDArray[np.floating]) -> None:
+        h = np.asarray(hop_samples, dtype=np.float64).ravel()
+        if h.size != self._hop:
+            raise ValueError(f"expected {self._hop} samples, got {h.size}")
+        if self._in_buf.size == 0:
+            self._in_buf = h
+        else:
+            self._in_buf = np.concatenate((self._in_buf, h))
+
+    def ready(self) -> bool:
+        return self._in_buf.size >= self._win_size
+
+    def next_frame(self) -> NDArray[np.float64]:
+        if not self.ready():
+            raise RuntimeError("not enough samples for a full frame")
+        x = self._in_buf[: self._win_size]
+        self._in_buf = self._in_buf[self._hop :]
+        return x * self._win_sqrt
+
+    def overlap_add(self, processed_frame: NDArray[np.floating]) -> NDArray[np.float64]:
+        p = np.asarray(processed_frame, dtype=np.float64).ravel()
+        if p.size != self._win_size:
+            raise ValueError(f"processed_frame must have length {self._win_size}")
+        self._ola += p * self._win_sqrt
+        out: NDArray[np.float64] = np.asarray(self._ola[: self._hop].copy(), dtype=np.float64)
+        # Shift accumulator left by one hop; zero the new tail for the next overlap.
+        w = self._win_size
+        h = self._hop
+        self._ola[: w - h] = self._ola[h:w]
+        self._ola[w - h :] = 0.0
+        return out
+
+
+def stft_frames(x: NDArray[np.floating], win_size: int, hop: int) -> NDArray[np.float64]:
+    """Offline stack of sqrt-Hann analysis frames (matches :class:`FrameBuffer`).
+
+    Frame ``k`` is ``x[k * hop : k * hop + win_size] * sqrt(hann_window(win_size))``.
+    Only complete frames are returned, shape ``(n_frames, win_size)``.
+    """
+    x = np.asarray(x, dtype=np.float64).ravel()
+    if x.size < win_size:
+        return np.zeros((0, win_size), dtype=np.float64)
+    w_sqrt = np.sqrt(hann_window(win_size))
+    n_frames = 1 + (x.size - win_size) // hop
+    if n_frames <= 0:
+        return np.zeros((0, win_size), dtype=np.float64)
+    windows = sliding_window_view(x, win_size)[::hop]
+    if windows.shape[0] > n_frames:
+        windows = windows[:n_frames]
+    return windows * w_sqrt

--- a/rfwhisper/dsp/features.py
+++ b/rfwhisper/dsp/features.py
@@ -98,7 +98,15 @@ def stft_frames(x: NDArray[np.floating], win_size: int, hop: int) -> NDArray[np.
     Frame ``k`` is ``x[k * hop : k * hop + win_size] * sqrt(hann_window(win_size))``.
     Only complete frames are returned, shape ``(n_frames, win_size)``.
     """
-    x = np.asarray(x, dtype=np.float64).ravel()
+    if win_size <= 0 or hop <= 0:
+        raise ValueError("win_size and hop must be positive")
+    if hop > win_size:
+        raise ValueError("hop must not exceed win_size")
+    x = np.asarray(x, dtype=np.float64)
+    if x.ndim != 1:
+        raise ValueError(
+            "expected a 1-D signal (shape (n,)); pass one channel at a time for multi-channel audio"
+        )
     if x.size < win_size:
         return np.zeros((0, win_size), dtype=np.float64)
     w_sqrt = np.sqrt(hann_window(win_size))

--- a/rfwhisper/dsp/features.py
+++ b/rfwhisper/dsp/features.py
@@ -35,9 +35,13 @@ class FrameBuffer:
       periodic Hann (``fftbins=True``); advancing the FIFO by ``hop``.
     * ``overlap_add`` does ``ola += processed * sqrt(w)`` and returns the next ``hop``
       samples from the accumulator (50 % overlap ⇒ overlapping Hann weights sum to 1).
+
+    Samples are held in a fixed-capacity ring buffer (``win_size + hop``) so ``push``
+    does not grow or concatenate on each hop—important for long streams and for
+    eventual realtime use (see AGENTS.md: avoid per-callback allocations).
     """
 
-    __slots__ = ("_hop", "_in_buf", "_ola", "_win_sqrt", "_win_size")
+    __slots__ = ("_cap", "_fifo", "_hop", "_n", "_ola", "_rd", "_win_sqrt", "_win_size")
 
     def __init__(self, win_size: int, hop: int) -> None:
         if win_size <= 0 or hop <= 0:
@@ -48,7 +52,10 @@ class FrameBuffer:
         self._hop = hop
         w = hann_window(win_size)
         self._win_sqrt = np.sqrt(w)
-        self._in_buf = np.zeros(0, dtype=np.float64)
+        self._cap = win_size + hop
+        self._fifo = np.zeros(self._cap, dtype=np.float64)
+        self._rd = 0
+        self._n = 0
         self._ola = np.zeros(win_size, dtype=np.float64)
 
     @property
@@ -60,28 +67,45 @@ class FrameBuffer:
         return self._hop
 
     def push(self, hop_samples: NDArray[np.floating]) -> None:
-        h = np.asarray(hop_samples, dtype=np.float64).ravel()
-        if h.size != self._hop:
-            raise ValueError(f"expected {self._hop} samples, got {h.size}")
-        if self._in_buf.size == 0:
-            self._in_buf = h
+        h = np.asarray(hop_samples, dtype=np.float64)
+        if h.ndim != 1 or h.shape[0] != self._hop:
+            raise ValueError(f"expected 1-D hop_samples with shape ({self._hop},), got {h.shape}")
+        if self._n + self._hop > self._cap:
+            raise ValueError(
+                "analysis fifo full: call next_frame() whenever ready() before pushing more hops"
+            )
+        wr = (self._rd + self._n) % self._cap
+        room = self._cap - wr
+        if room >= self._hop:
+            self._fifo[wr : wr + self._hop] = h
         else:
-            self._in_buf = np.concatenate((self._in_buf, h))
+            self._fifo[wr:] = h[:room]
+            self._fifo[: self._hop - room] = h[room:]
+        self._n += self._hop
 
     def ready(self) -> bool:
-        return self._in_buf.size >= self._win_size
+        return self._n >= self._win_size
 
     def next_frame(self) -> NDArray[np.float64]:
         if not self.ready():
             raise RuntimeError("not enough samples for a full frame")
-        x = self._in_buf[: self._win_size]
-        self._in_buf = self._in_buf[self._hop :]
-        return x * self._win_sqrt
+        wsz = self._win_size
+        x = np.empty(wsz, dtype=np.float64)
+        first = min(wsz, self._cap - self._rd)
+        x[:first] = self._fifo[self._rd : self._rd + first]
+        if first < wsz:
+            x[first:] = self._fifo[: wsz - first]
+        self._rd = (self._rd + self._hop) % self._cap
+        self._n -= self._hop
+        x *= self._win_sqrt
+        return x
 
     def overlap_add(self, processed_frame: NDArray[np.floating]) -> NDArray[np.float64]:
-        p = np.asarray(processed_frame, dtype=np.float64).ravel()
-        if p.size != self._win_size:
-            raise ValueError(f"processed_frame must have length {self._win_size}")
+        p = np.asarray(processed_frame, dtype=np.float64)
+        if p.ndim != 1 or p.shape[0] != self._win_size:
+            raise ValueError(
+                f"expected 1-D processed_frame with shape ({self._win_size},), got {p.shape}"
+            )
         self._ola += p * self._win_sqrt
         out: NDArray[np.float64] = np.asarray(self._ola[: self._hop].copy(), dtype=np.float64)
         # Shift accumulator left by one hop; zero the new tail for the next overlap.

--- a/rfwhisper/dsp/resample.py
+++ b/rfwhisper/dsp/resample.py
@@ -1,0 +1,23 @@
+"""Stateless polyphase resampling between 48 kHz and 16 kHz model I/O rates."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.signal import resample_poly
+
+
+def resample_48k_to_16k(x: NDArray[np.floating]) -> NDArray[np.float64]:
+    """48 kHz → 16 kHz via polyphase ``resample_poly`` (``up=1``, ``down=3``)."""
+    x = np.asarray(x, dtype=np.float64)
+    if x.ndim != 1:
+        x = x.ravel()
+    return np.asarray(resample_poly(x, up=1, down=3), dtype=np.float64)
+
+
+def resample_16k_to_48k(x: NDArray[np.floating]) -> NDArray[np.float64]:
+    """16 kHz → 48 kHz via polyphase ``resample_poly`` (``up=3``, ``down=1``)."""
+    x = np.asarray(x, dtype=np.float64)
+    if x.ndim != 1:
+        x = x.ravel()
+    return np.asarray(resample_poly(x, up=3, down=1), dtype=np.float64)

--- a/rfwhisper/dsp/resample.py
+++ b/rfwhisper/dsp/resample.py
@@ -7,17 +7,22 @@ from numpy.typing import NDArray
 from scipy.signal import resample_poly
 
 
+def _require_mono_1d(x: np.ndarray) -> np.ndarray:
+    if x.ndim != 1:
+        raise ValueError(
+            "expected a 1-D mono signal (shape (n,)); multi-channel audio must be "
+            "resampled per channel"
+        )
+    return x
+
+
 def resample_48k_to_16k(x: NDArray[np.floating]) -> NDArray[np.float64]:
     """48 kHz → 16 kHz via polyphase ``resample_poly`` (``up=1``, ``down=3``)."""
-    x = np.asarray(x, dtype=np.float64)
-    if x.ndim != 1:
-        x = x.ravel()
+    x = _require_mono_1d(np.asarray(x, dtype=np.float64))
     return np.asarray(resample_poly(x, up=1, down=3), dtype=np.float64)
 
 
 def resample_16k_to_48k(x: NDArray[np.floating]) -> NDArray[np.float64]:
     """16 kHz → 48 kHz via polyphase ``resample_poly`` (``up=3``, ``down=1``)."""
-    x = np.asarray(x, dtype=np.float64)
-    if x.ndim != 1:
-        x = x.ravel()
+    x = _require_mono_1d(np.asarray(x, dtype=np.float64))
     return np.asarray(resample_poly(x, up=3, down=1), dtype=np.float64)

--- a/tests/dsp/test_features.py
+++ b/tests/dsp/test_features.py
@@ -1,0 +1,94 @@
+"""Tests for framing, Hann windows, overlap-add, and STFT frame stacking."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from rfwhisper.dsp.features import (
+    HOP_16K,
+    HOP_48K,
+    WIN_16K,
+    WIN_48K,
+    FrameBuffer,
+    hann_window,
+    stft_frames,
+)
+
+
+def test_hann_matches_scipy_fftbins() -> None:
+    scipy_signal = pytest.importorskip("scipy.signal", reason="scipy required for reference")
+    get_window = scipy_signal.get_window
+    for n in (320, 960, 100):
+        ref = get_window("hann", n, fftbins=True).astype(np.float64)
+        got = hann_window(n)
+        np.testing.assert_allclose(got, ref, rtol=0, atol=1e-15)
+
+
+def test_constants_ten_ms_hop() -> None:
+    assert HOP_48K == pytest.approx(0.01 * 48_000)
+    assert WIN_48K == 2 * HOP_48K
+    assert HOP_16K == pytest.approx(0.01 * 16_000)
+    assert WIN_16K == 2 * HOP_16K
+
+
+def test_ola_hann_half_overlap_sums_to_unity() -> None:
+    """WOLA gain: two 50 %-overlapped Hann windows sum to 1 (linear COLA)."""
+    w = hann_window(WIN_48K)
+    hop = HOP_48K
+    assert hop * 2 == WIN_48K
+    for i in range(hop, WIN_48K):
+        s = float(w[i] + w[i - hop])
+        assert s == pytest.approx(1.0, abs=1e-6)
+
+
+def test_frame_buffer_sine_roundtrip_steady_state() -> None:
+    sr = 48_000
+    duration = 1.0
+    f0 = 1_000.0
+    t = np.arange(int(sr * duration), dtype=np.float64) / sr
+    x = np.sin(2.0 * np.pi * f0 * t)
+
+    fb = FrameBuffer(WIN_48K, HOP_48K)
+    out_chunks: list[NDArray[np.float64]] = []
+
+    def feed_hops(sig: NDArray[np.float64]) -> None:
+        hop = HOP_48K
+        n = sig.size
+        pad = (hop - (n % hop)) % hop
+        if pad:
+            sig = np.concatenate((sig, np.zeros(pad, dtype=np.float64)))
+        for i in range(0, sig.size, hop):
+            fb.push(sig[i : i + hop])
+            while fb.ready():
+                frame = fb.next_frame()
+                out_chunks.append(fb.overlap_add(frame))
+
+    feed_hops(x)
+    warmup = WIN_48K - HOP_48K
+    # One extra window of synthesis tail beyond input length (COLA drain).
+    need = warmup + x.size + WIN_48K
+    while sum(c.size for c in out_chunks) < need:
+        fb.push(np.zeros(HOP_48K, dtype=np.float64))
+        while fb.ready():
+            frame = fb.next_frame()
+            out_chunks.append(fb.overlap_add(frame))
+
+    y = np.concatenate(out_chunks)
+    y_ss = y[warmup : warmup + x.size]
+    # With F = (N - W) / H + 1 frames, COLA emits F * H = N - (W - H) steady-state
+    # samples that match the input; the last (W - H) samples need further tail flush
+    # beyond this acceptance test's scope.
+    steady = x.size - (WIN_48K - HOP_48K)
+    np.testing.assert_allclose(y_ss[:steady], x[:steady], rtol=1e-3, atol=5e-3)
+
+
+def test_stft_frames_shape_and_matches_manual() -> None:
+    x = np.random.default_rng(0).standard_normal(5_000).astype(np.float64)
+    win, hop = 320, 160
+    frames = stft_frames(x, win, hop)
+    w_sqrt = np.sqrt(hann_window(win))
+    n_frames = 1 + (x.size - win) // hop
+    assert frames.shape == (n_frames, win)
+    np.testing.assert_allclose(frames[3], x[3 * hop : 3 * hop + win] * w_sqrt, rtol=0, atol=1e-15)

--- a/tests/dsp/test_features.py
+++ b/tests/dsp/test_features.py
@@ -84,6 +84,22 @@ def test_frame_buffer_sine_roundtrip_steady_state() -> None:
     np.testing.assert_allclose(y_ss[:steady], x[:steady], rtol=1e-3, atol=5e-3)
 
 
+def test_stft_frames_rejects_invalid_params() -> None:
+    x = np.zeros(100, dtype=np.float64)
+    with pytest.raises(ValueError, match="win_size and hop must be positive"):
+        stft_frames(x, win_size=0, hop=10)
+    with pytest.raises(ValueError, match="win_size and hop must be positive"):
+        stft_frames(x, win_size=32, hop=0)
+    with pytest.raises(ValueError, match="hop must not exceed win_size"):
+        stft_frames(x, win_size=32, hop=64)
+
+
+def test_stft_frames_rejects_non_1d() -> None:
+    x2 = np.zeros((50, 2), dtype=np.float64)
+    with pytest.raises(ValueError, match="1-D signal"):
+        stft_frames(x2, win_size=16, hop=8)
+
+
 def test_stft_frames_shape_and_matches_manual() -> None:
     x = np.random.default_rng(0).standard_normal(5_000).astype(np.float64)
     win, hop = 320, 160

--- a/tests/dsp/test_features.py
+++ b/tests/dsp/test_features.py
@@ -20,7 +20,7 @@ from rfwhisper.dsp.features import (
 def test_hann_matches_scipy_fftbins() -> None:
     scipy_signal = pytest.importorskip("scipy.signal", reason="scipy required for reference")
     get_window = scipy_signal.get_window
-    for n in (320, 960, 100):
+    for n in (1, 100, 320, 960):
         ref = get_window("hann", n, fftbins=True).astype(np.float64)
         got = hann_window(n)
         np.testing.assert_allclose(got, ref, rtol=0, atol=1e-15)

--- a/tests/dsp/test_resample.py
+++ b/tests/dsp/test_resample.py
@@ -1,0 +1,45 @@
+"""Polyphase resampler tests."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.signal import correlate
+
+from rfwhisper.dsp.resample import resample_16k_to_48k, resample_48k_to_16k
+
+
+def test_resample_roundtrip_1khz_under_60_db() -> None:
+    sr_in = 48_000
+    duration = 6.0
+    f0 = 1_000.0
+    t = np.arange(int(sr_in * duration), dtype=np.float64) / sr_in
+    x = np.sin(2.0 * np.pi * f0 * t)
+
+    y = resample_48k_to_16k(x)
+    assert y.shape == (int(sr_in * duration / 3),)
+    z = resample_16k_to_48k(y)
+    assert z.shape == x.shape
+
+    trim = sr_in // 2
+    x_mid = x[trim:-trim]
+    z_mid = z[trim:-trim]
+
+    corr = correlate(z_mid, x_mid, mode="full")
+    lag = int(np.argmax(np.abs(corr)) - (z_mid.size - 1))
+
+    if lag >= 0:
+        m = min(z_mid.size - lag, x_mid.size)
+        z_a = z_mid[lag : lag + m]
+        x_a = x_mid[:m]
+    else:
+        lag_abs = -lag
+        m = min(z_mid.size, x_mid.size - lag_abs)
+        z_a = z_mid[:m]
+        x_a = x_mid[lag_abs : lag_abs + m]
+
+    gain = float(np.dot(z_a, x_a) / (np.dot(x_a, x_a) + 1e-20))
+    err = z_a - gain * x_a
+    rms_sig = float(np.sqrt(np.mean(x_a**2)))
+    rms_err = float(np.sqrt(np.mean(err**2)))
+    err_db = 20.0 * np.log10(rms_err / (rms_sig + 1e-20))
+    assert err_db < -60.0

--- a/tests/dsp/test_resample.py
+++ b/tests/dsp/test_resample.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 import numpy as np
 from scipy.signal import correlate
 
+import pytest
+
 from rfwhisper.dsp.resample import resample_16k_to_48k, resample_48k_to_16k
+
+
+def test_resample_rejects_non_1d() -> None:
+    stereo = np.zeros((100, 2), dtype=np.float64)
+    with pytest.raises(ValueError, match="1-D mono"):
+        resample_48k_to_16k(stereo)
 
 
 def test_resample_roundtrip_1khz_under_60_db() -> None:


### PR DESCRIPTION
Add the foundational DSP package for issue #2: shared hop/window sizes for 48 kHz and 16 kHz (10 ms hop at both rates), a periodic Hann that matches SciPy’s fftbins=True convention, a streaming FrameBuffer with push / ready / next_frame / overlap_add, and offline stft_frames for vectorized tests.

FrameBuffer uses sqrt-Hann analysis and synthesis (WOLA) so 50 % overlap satisfies COLA (overlapping linear Hann weights sum to 1). That gives a stable identity path for the sine round-trip test; using the full window twice would not meet the stated OLA gain criterion.

Resampling is stateless polyphase via scipy.signal.resample_poly (down 3, up 3) between 48 kHz and 16 kHz. scipy is promoted to a core dependency so rfwhisper.dsp imports without the audio extra; the module still avoids onnxruntime, sounddevice, and model code at import time.

Tests cover Hann vs SciPy, COLA gain, FrameBuffer steady-state reconstruction (explicit length N − (W − H) after the documented warm-up), stft_frames parity with the streaming window, and 48→16→48 round-trip error well below −60 dB on a 1 kHz tone after mid-segment alignment (group delay / scaling).

Also add a minimal package skeleton (py.typed, version, argparse CLI stub) so the project installs and CI can run mypy on rfwhisper; configure mypy to ignore missing stubs for scipy.signal.

Refs: https://github.com/JakenHerman/RFWhisper/issues/2