### PR TITLE
feat(pkg): scaffold installable rfwhisper package (v0.1 skeleton)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,49 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfwhisper"
-version = "0.1.0"
+version = "0.1.0a0"
 description = "Real-time ML noise reduction for amateur radio"
 readme = "README.md"
 license = { text = "GPL-3.0-or-later" }
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Jaken Herman" }]
+keywords = [
+  "amateur-radio",
+  "audio",
+  "denoising",
+  "dsp",
+  "ham-radio",
+  "noise-reduction",
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+  "Operating System :: MacOS",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: POSIX :: Linux",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Communications :: Ham Radio",
+  "Topic :: Multimedia :: Sound/Audio",
+  "Topic :: Scientific/Engineering",
+]
 dependencies = [
   "numpy>=1.24",
+  "onnxruntime>=1.15",
+  "pyyaml>=6.0",
+  "rich>=13.0",
   "scipy>=1.10",
+  "soundfile>=0.12",
+  "typer>=0.12",
 ]
 
 [project.optional-dependencies]
+audio = ["sounddevice>=0.4"]
+gui = ["PySide6>=6.5"]
+eval = ["pesq", "pystoi"]
 dev = [
   "mypy>=1.10",
   "pre-commit",
@@ -22,20 +54,14 @@ dev = [
   "pytest-xdist",
   "ruff>=0.5",
 ]
-audio = [
-  "onnxruntime>=1.15",
-  "scipy>=1.10",
-  "sounddevice>=0.4",
-  "soundfile>=0.12",
-]
-eval = [
-  "pesq",
-  "pystoi",
-  "scipy>=1.10",
-]
+
+[project.urls]
+Homepage = "https://github.com/JakenHerman/rfwhisper"
+Repository = "https://github.com/JakenHerman/rfwhisper"
+Issues = "https://github.com/JakenHerman/rfwhisper/issues"
 
 [project.scripts]
-rfwhisper = "rfwhisper.cli:main"
+rfwhisper = "rfwhisper.cli:app"
 
 [tool.setuptools.packages.find]
 include = ["rfwhisper*"]
@@ -56,9 +82,18 @@ strict = true
 warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
-module = ["pesq", "pystoi", "pesq.pesq"]
+module = [
+  "onnxruntime",
+  "pesq",
+  "pesq.pesq",
+  "pystoi",
+  "scipy.signal",
+  "sounddevice",
+  "soundfile",
+  "yaml",
+]
 ignore_missing_imports = true
 
-[[tool.mypy.overrides]]
-module = ["scipy.signal"]
-ignore_missing_imports = true
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = ["-ra"]

--- a/rfwhisper/__init__.py
+++ b/rfwhisper/__init__.py
@@ -1,3 +1,3 @@
 """RFWhisper — real-time ML noise reduction for amateur radio."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.0a0"

--- a/rfwhisper/bench/__init__.py
+++ b/rfwhisper/bench/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmarking and quality-gate harnesses (filled in by later milestones)."""

--- a/rfwhisper/cli.py
+++ b/rfwhisper/cli.py
@@ -1,14 +1,30 @@
-"""CLI entrypoint (expanded in later milestones)."""
+"""CLI entrypoint — placeholder Typer app; subcommands land in later milestones."""
 
 from __future__ import annotations
 
-import argparse
+import typer
 
 from rfwhisper import __version__
 
+app = typer.Typer(
+    name="rfwhisper",
+    help="RFWhisper — real-time ML noise reduction for amateur radio.",
+    add_completion=False,
+)
 
-def main() -> None:
-    parser = argparse.ArgumentParser(prog="rfwhisper", description="RFWhisper denoiser CLI")
-    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
-    parser.parse_args()
-    parser.print_help()
+
+@app.callback(invoke_without_command=True)
+def main(
+    ctx: typer.Context,
+    version: bool = typer.Option(
+        False,
+        "--version",
+        help="Show the version and exit.",
+    ),
+) -> None:
+    """RFWhisper CLI."""
+    if version:
+        typer.echo(f"rfwhisper {__version__}")
+        raise typer.Exit()
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())

--- a/rfwhisper/gui/__init__.py
+++ b/rfwhisper/gui/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-platform GUI (PySide6) entrypoints (filled in by later milestones)."""

--- a/rfwhisper/models/__init__.py
+++ b/rfwhisper/models/__init__.py
@@ -1,0 +1,1 @@
+"""Model loading, fetching, and ONNX runners (filled in by later milestones)."""

--- a/rfwhisper/realtime/__init__.py
+++ b/rfwhisper/realtime/__init__.py
@@ -1,0 +1,1 @@
+"""Real-time audio I/O and streaming pipeline (filled in by later milestones)."""

--- a/tests/dsp/test_resample.py
+++ b/tests/dsp/test_resample.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import numpy as np
-from scipy.signal import correlate
-
 import pytest
+from scipy.signal import correlate
 
 from rfwhisper.dsp.resample import resample_16k_to_48k, resample_48k_to_16k
 


### PR DESCRIPTION
Closes #5.

## Summary

Lays down the minimal installable `rfwhisper` package — the shell every
other v0.1 issue plugs modules into. Matches ROADMAP A7 (cross-platform
install + CI matrix) and what `.github/workflows/basic-ci.yml` already
expects.

## What's in

- **`pyproject.toml`** (PEP 621):
  - version `0.1.0a0`, Python `>=3.10,<3.13`, GPL-3.0-or-later
  - project URLs + classifiers (Ham Radio / Audio / Scientific)
  - runtime deps: `numpy`, `scipy`, `soundfile`, `onnxruntime`, `typer`,
    `rich`, `pyyaml`
  - extras: `[audio]` (sounddevice), `[gui]` (PySide6), `[eval]`
    (pesq, pystoi), `[dev]` (ruff, mypy, pytest, pytest-xdist, pre-commit)
  - console script: `rfwhisper = "rfwhisper.cli:app"`
  - ruff / mypy (`strict = true`) / pytest config blocks
- **`rfwhisper/__init__.py`** — `__version__ = "0.1.0a0"`
- **`rfwhisper/cli.py`** — Typer `app` with `--version`; subcommands land
  in later milestones
- **Submodule stubs**: `models/`, `realtime/`, `bench/`, `gui/` so future
  issues have a place to land (`dsp/` already exists)
- **`py.typed`** is preserved and shipped via `package-data`

## What's deliberately out

Per the issue's non-goals: no real DSP/model/CLI functionality (each is
its own issue), and no native-extension wheels (deferred to v0.2).

## Drive-by

Fixed a pre-existing `I001` import-order error in
`tests/dsp/test_resample.py` so `ruff check .` is green on a clean
checkout. Tiny, in-scope of "lint baseline must pass."

## Acceptance checks (verified locally on Python 3.12, Windows)

- [x] `pip install -e ".[dev]"` succeeds
- [x] `ruff format --check .` green
- [x] `ruff check .` green
- [x] `mypy --strict rfwhisper` green (9 files)
- [x] `rfwhisper --version` → `rfwhisper 0.1.0a0`
- [x] `python -m build` + `python -m twine check dist/*` PASSED

Cross-platform / cross-Python verification will run in CI via the
existing `basic-ci.yml` matrix (`ubuntu-22.04`, `macos-13`,
`windows-2022` × py3.10/3.11/3.12) and the package smoke job.

## Test plan

- [ ] CI `lint` job green (ruff format, ruff check, mypy strict)
- [ ] CI `unit` matrix green across Linux / macOS / Windows × 3.10–3.12
- [ ] CI `package` smoke job green (`python -m build` + `twine check`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily packaging/metadata and a minimal CLI entrypoint swap, with no core DSP/model logic modifications.
> 
> **Overview**
> Sets up `rfwhisper` as an installable package by expanding `pyproject.toml` with PEP 621 metadata (alpha version `0.1.0a0`, Python `>=3.10,<3.13`, runtime deps, extras, URLs) plus pytest/mypy tooling config.
> 
> Switches the console script to a Typer-based `rfwhisper.cli:app` (supports `--version` and help) and adds placeholder subpackages (`bench`, `models`, `realtime`, `gui`) for future work. Also fixes a minor import-order issue in `tests/dsp/test_resample.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf52f46505ed2b05d9d5e3f0cfffa674ef56da1c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->