### PR TITLE
docs(agents): add Copilot + Cursor rules slices that point at AGENTS.md

### DIFF
--- a/.cursor/rules.md
+++ b/.cursor/rules.md
@@ -1,0 +1,30 @@
+# RFWhisper — Cursor Rules for AI
+
+> Condensed slice of [AGENTS.md](../AGENTS.md), the source of truth — read it for role prompts, the full latency table, the ham-radio domain primer, and the PR rubric. **If you change AGENTS.md and it touches anything below, update this file in the same PR.**
+
+## What we're building
+
+Real-time ML noise reduction for amateur radio. Local-first. **GPLv3-or-later.**
+
+## Primary stack
+
+- **Primary denoiser:** DeepFilterNet3 (DFN3) — ham-fine-tuned **ONNX**, ONNX Runtime 1.17+, opset ≥ 17.
+- **Fallback denoiser:** RNNoise (Valin / Xiph) — ham-retuned ONNX, for the RPi Zero / low-power tier.
+- **DSP / RF:** GNU Radio 3.10.x (LTS), SoapySDR, liquid-dsp, VOLK.
+- **Languages:** Python 3.10+ (glue, CLI, GUI), C++17 (GR blocks + hot paths), Rust optional.
+
+## Hard constraints
+
+1. **Latency:** v0.1 end-to-end **< 100 ms p99** on i5-8xxx / M1 / RPi 5; v0.3 target < 50 ms. If you can't measure your change's latency impact, you haven't finished it.
+2. **Non-regression gates — never bypass:**
+   - **A3 — CW keying transient:** RMS in the first 5 ms of a dit stays within **±1 dB** of raw (`tests/audio/cw_transient_test.py`).
+   - **A2 — FT8 decode count:** denoised decodes **≥** raw, **zero** false decodes (`tests/audio/ft8_regression_test.py`).
+3. **GPLv3-compatible deps only.** MIT / Apache / BSD: fine. Proprietary or GPL-incompatible: never.
+4. **Local-first.** No network calls in runtime paths. Models fetched once, SHA-256 pinned in source.
+5. **No allocations in the audio callback.** Preallocate buffers, reuse plans, release the GIL around inference.
+6. **Every PR moves one roadmap criterion forward** (A*/B*/C*/D*/E*/F* in [ROADMAP.md](../ROADMAP.md)) and reports p50/p99 latency on the changed path.
+
+## Conventions
+
+- Conventional Commits (`feat:`, `fix:`, `perf:`, `test:`, …) with roadmap refs in the body (e.g. `refs A2`).
+- Python: `ruff format`, `ruff check`, `mypy --strict` on new code. C++17 with repo `.clang-format`. Rust: `rustfmt`, `clippy -D warnings`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,30 @@
+# RFWhisper — Copilot Instructions
+
+> Condensed slice of [AGENTS.md](../AGENTS.md), the source of truth — read it for role prompts, the full latency table, the ham-radio domain primer, and the PR rubric. **If you change AGENTS.md and it touches anything below, update this file in the same PR.**
+
+## What we're building
+
+Real-time ML noise reduction for amateur radio. Local-first. **GPLv3-or-later.**
+
+## Primary stack
+
+- **Primary denoiser:** DeepFilterNet3 (DFN3) — ham-fine-tuned **ONNX**, ONNX Runtime 1.17+, opset ≥ 17.
+- **Fallback denoiser:** RNNoise (Valin / Xiph) — ham-retuned ONNX, for the RPi Zero / low-power tier.
+- **DSP / RF:** GNU Radio 3.10.x (LTS), SoapySDR, liquid-dsp, VOLK.
+- **Languages:** Python 3.10+ (glue, CLI, GUI), C++17 (GR blocks + hot paths), Rust optional.
+
+## Hard constraints
+
+1. **Latency:** v0.1 end-to-end **< 100 ms p99** on i5-8xxx / M1 / RPi 5; v0.3 target < 50 ms. If you can't measure your change's latency impact, you haven't finished it.
+2. **Non-regression gates — never bypass:**
+   - **A3 — CW keying transient:** RMS in the first 5 ms of a dit stays within **±1 dB** of raw (`tests/audio/cw_transient_test.py`).
+   - **A2 — FT8 decode count:** denoised decodes **≥** raw, **zero** false decodes (`tests/audio/ft8_regression_test.py`).
+3. **GPLv3-compatible deps only.** MIT / Apache / BSD: fine. Proprietary or GPL-incompatible: never.
+4. **Local-first.** No network calls in runtime paths. Models fetched once, SHA-256 pinned in source.
+5. **No allocations in the audio callback.** Preallocate buffers, reuse plans, release the GIL around inference.
+6. **Every PR moves one roadmap criterion forward** (A*/B*/C*/D*/E*/F* in [ROADMAP.md](../ROADMAP.md)) and reports p50/p99 latency on the changed path.
+
+## Conventions
+
+- Conventional Commits (`feat:`, `fix:`, `perf:`, `test:`, …) with roadmap refs in the body (e.g. `refs A2`).
+- Python: `ruff format`, `ruff check`, `mypy --strict` on new code. C++17 with repo `.clang-format`. Rust: `rustfmt`, `clippy -D warnings`.

--- a/.gitignore
+++ b/.gitignore
@@ -270,7 +270,8 @@ $RECYCLE.BIN/
 .idea/
 .vscode/
 .claude/
-.cursor/
+.cursor/*
+!.cursor/rules.md
 .aider*
 !.vscode/settings.json.example
 !.vscode/extensions.json.example

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 
 If you are an AI agent reading this: **read the whole file before writing code.** It contains the canonical tech stack, latency budgets, testability rules, and the specialized role-based system prompts you should load when working on different parts of the project.
 
+> **If you edit this file**, condensed slices live at [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) (Copilot Workspace / Chat) and [`.cursor/rules.md`](./.cursor/rules.md) (Cursor) for tools that don't auto-load AGENTS.md. When you change §Prime Directives, §Shared Context, §Real-Time Constraints, or the cited roadmap gates (A2 / A3), update both slice files in the same PR to keep them in sync.
+
 ---
 
 ## Table of Contents


### PR DESCRIPTION
## Summary

- Adds [`.github/copilot-instructions.md`](.github/copilot-instructions.md) (GitHub Copilot Workspace / Chat) and [`.cursor/rules.md`](.cursor/rules.md) (Cursor) — both ≤ ~2 KB condensed slices of [AGENTS.md](AGENTS.md) so tools that don't auto-load AGENTS.md still see the load-bearing rules.
- Each slice covers: DFN3 ONNX primary + RNNoise fallback, v0.1 **< 100 ms p99** end-to-end latency, **A3** CW transient and **A2** FT8 decode non-regression gates, GPLv3 dep constraint, and a pointer back to AGENTS.md.
- Drift prevention via top-of-file reminders in each slice + a reciprocal note in AGENTS.md telling editors to update both slice files in the same PR (per issue #28's "top-of-file reminder" option).
- `.gitignore` fix: switched `.cursor/` → `.cursor/*` + `!.cursor/rules.md` so the new file is actually trackable. Without this, `.cursor/rules.md` would have been silently ignored (the existing `!.vscode/*.example` exception under `.vscode/` is itself a no-op for the same reason — that's a pre-existing bug; not fixing it here to keep the PR scoped).

Resolves #28.

## Out of scope

- Aider / Codex / Claude Code (`CLAUDE.md`) — they already read AGENTS.md-style files (per the issue's non-goals).
- Per-subdirectory rules (v0.2+).
- Repairing the latent `.vscode/*.example` re-inclusion bug — separate PR if anyone cares.

## Test plan

- [ ] **Copilot Workspace / Chat (manual)**: open a new Copilot session in VS Code on this branch and confirm `copilot-instructions.md` is surfaced (chat says it loaded the repo's instructions, or the rules text is reflected in responses).
- [ ] **Cursor (manual)**: open Cursor on this branch and confirm `.cursor/rules.md` appears in the "Rules for AI" pane.
- [ ] Byte budget check: both files are ≤ 2 KB (current: 2041 / 2040 bytes).
- [ ] All five must-have content items present in both slices: DFN3 primary, RNNoise fallback, < 100 ms p99 latency, A3 + A2 non-regression gates, GPLv3 dep constraint, pointer to AGENTS.md.
- [ ] Drift reminder visible at top of each slice and reciprocally in AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)